### PR TITLE
Cross-build for Scala 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: scala
 
 script:
-  - sbt clean compile
+  - sbt clean +test

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 The `http4s-pac4j` project is an **easy and powerful security library for http4s web applications and web services** which supports authentication and authorization, but also logout and advanced features like session fixation and CSRF protection.
-It's based on Scala 2.12, Http4s 0.21 and on the **[pac4j security engine](https://github.com/pac4j/pac4j) v3**. It's available under the Apache 2 license.
+It's based on Http4s 0.21 and on the **[pac4j security engine](https://github.com/pac4j/pac4j) v3**. The library is cross-built for Scala 2.12 and 2.13. It's available under the Apache 2 license.
 
 [**Main concepts and components:**](http://www.pac4j.org/docs/main-concepts-and-components.html)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.12.11" // Also supports 2.11.x
+crossScalaVersions := Seq("2.12.12", "2.13.3")
 organization := "org.pac4j"
 version      := "1.0.1-SNAPSHOT"
 
@@ -59,4 +59,15 @@ publishTo := {
 }
 publishMavenStyle := true
 
-scalacOptions ++= Seq("-Ypartial-unification", "-language:implicitConversions", "-language:higherKinds")
+scalacOptions ++= {
+  val scalaVersion0 = scalaVersion.value
+  val partialUnification =
+    if (scalaVersion0.startsWith("2.12")) {
+      Seq("-Ypartial-unification")
+    } else Seq()
+
+  partialUnification ++ Seq(
+    "-language:implicitConversions",
+    "-language:higherKinds"
+  )
+}

--- a/src/test/scala/org/pac4j/http4s/SessionSpec.scala
+++ b/src/test/scala/org/pac4j/http4s/SessionSpec.scala
@@ -22,7 +22,7 @@ import cats.data.NonEmptyList
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 import org.specs2.ScalaCheck
-import org.specs2.matcher.{Matcher, IOMatchers}
+import org.specs2.matcher.{Matcher, IOMatchers, TraversableMatchers}
 import org.specs2.mutable.Specification
 import org.specs2.concurrent.ExecutionEnv
 import mouse.option._
@@ -72,6 +72,10 @@ object Matchers {
 }
 
 class SessionSpec(val exEnv: ExecutionEnv) extends Specification with ScalaCheck with IOMatchers {
+
+  // A workaround for some weird overloading behavior with Scala 2.13.
+  import TraversableMatchers.{contain => contain0}
+
   implicit class ResponseCookieOps(c: ResponseCookie) {
     def toRequestCookie: RequestCookie = RequestCookie(c.name, c.content)
   }
@@ -126,7 +130,7 @@ class SessionSpec(val exEnv: ExecutionEnv) extends Specification with ScalaCheck
       "set a session cookie as per mkCookie" in prop { session: Session =>
         val request = Request[IO](Method.GET, uri"/create")
         sut(request).map(setCookies _) must
-          returnValue(contain(beCookieWithName(config.cookieName)))
+          returnValue(contain0(beCookieWithName(config.cookieName)))
       }
 
       "not include the session data in a readable form in the cookie" in {


### PR DESCRIPTION
Fixes #6 

There's some odd overload resolution conflict in one test, which I had to work around using a renamed import.

Publishing is now `sbt +publish` instead of `sbt publish` (`+` means "run the task for all `crossScalaVersions`").