### PR TITLE
Provide AuthedRoutes instead of HttpRoutes from the middleware.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "org.pac4j"
 version      := "2.0.0-SNAPSHOT"
 
 val circeVersion = "0.13.0"
-val http4sVersion = "0.21.6"
+val http4sVersion = "0.21.6+"
 val pac4jVersion = "3.9.0"
 val specs2Version = "4.10.0"
 val catsVersion = "2.1.1"

--- a/src/main/scala/org/pac4j/http4s/SecurityFilterMiddleware.scala
+++ b/src/main/scala/org/pac4j/http4s/SecurityFilterMiddleware.scala
@@ -6,15 +6,16 @@ import cats.implicits._
 import cats.effect._
 import org.http4s.server.{HttpMiddleware, Middleware}
 import org.http4s.{HttpRoutes, Response}
+
+import cats.effect.IO
+import org.http4s.server.AuthMiddleware
+import org.http4s.{AuthedRoutes, ContextRequest, Response}
 import org.http4s.implicits._
 import org.pac4j.core.config.Config
-import org.pac4j.core.engine.{
-  DefaultSecurityLogic,
-  SecurityGrantedAccessAdapter
-}
+import org.pac4j.core.engine.{DefaultSecurityLogic, SecurityGrantedAccessAdapter}
 import org.pac4j.core.http.adapter.HttpActionAdapter
 import org.pac4j.core.profile.CommonProfile
-import cats.data.OptionT
+import cats.data.{Kleisli, OptionT}
 
 /**
   * DefaultSecurityGrantedAccessAdapter gets called if user is granted access
@@ -23,14 +24,14 @@ import cats.data.OptionT
   *
   * @param service The http4s route that is being protected
   */
-class DefaultSecurityGrantedAccessAdapter(service: HttpRoutes[IO])
+class DefaultSecurityGrantedAccessAdapter(service: AuthedRoutes[util.Collection[CommonProfile], IO])
     extends SecurityGrantedAccessAdapter[IO[Response[IO]], Http4sWebContext] {
   override def adapt(
       context: Http4sWebContext,
       profiles: util.Collection[CommonProfile],
       parameters: AnyRef*
   ): IO[Response[IO]] = {
-    service.orNotFound(context.getRequest)
+    service.orNotFound(ContextRequest(profiles, context.getRequest))
   }
 }
 
@@ -41,7 +42,6 @@ class DefaultSecurityGrantedAccessAdapter(service: HttpRoutes[IO])
   * @author Iain Cardnell
   */
 object SecurityFilterMiddleware {
-
   def securityFilter(
       config: Config,
       blocker: Blocker,
@@ -49,27 +49,29 @@ object SecurityFilterMiddleware {
       authorizers: Option[String] = None,
       matchers: Option[String] = None,
       multiProfile: Boolean = false,
-      securityGrantedAccessAdapter: HttpRoutes[IO] => SecurityGrantedAccessAdapter[
+      securityGrantedAccessAdapter: AuthedRoutes[util.Collection[CommonProfile], IO] => SecurityGrantedAccessAdapter[
         IO[Response[IO]],
         Http4sWebContext
       ] = new DefaultSecurityGrantedAccessAdapter(_)
-    )(implicit cs: ContextShift[IO]): HttpMiddleware[IO] =
-    Middleware { (request, service) =>
-      val securityLogic =
-        new DefaultSecurityLogic[IO[Response[IO]], Http4sWebContext]
-      val context = Http4sWebContext(request, config)
-      OptionT.liftF(
-        blocker.delay[IO, IO[Response[IO]]](securityLogic.perform(
-          context,
-          config,
-          securityGrantedAccessAdapter(service),
-          config.getHttpActionAdapter
-            .asInstanceOf[HttpActionAdapter[IO[Response[IO]], Http4sWebContext]],
-          clients.orNull,
-          authorizers.orNull,
-          matchers.orNull,
-          multiProfile
+  )(implicit cs: ContextShift[IO]): AuthMiddleware[IO, util.Collection[CommonProfile]] =
+    service =>
+      Kleisli(request => {
+        val securityLogic =
+          new DefaultSecurityLogic[IO[Response[IO]], Http4sWebContext]
+        val context = Http4sWebContext(request, config)
+        OptionT.liftF(
+          blocker.delay[IO, IO[Response[IO]]](securityLogic.perform(
+            context,
+            config,
+            securityGrantedAccessAdapter(service),
+            config.getHttpActionAdapter
+              .asInstanceOf[HttpActionAdapter[IO[Response[IO]], Http4sWebContext]],
+            clients.orNull,
+            authorizers.orNull,
+            matchers.orNull,
+            multiProfile
+          )).flatten
         )
-      ).flatten)
-    }
+      }
+    )
 }


### PR DESCRIPTION
This is a more recent addition to http4s, but it makes sense to make the authorisation and users explicit in the routing.

This is a pretty minor change, but it means that one can pattern match on the users when building the routes; which is quite convenient.