### PR TITLE
Pac4j 5.1 support, Scala 3 support, abtract effect from implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,15 @@
-crossScalaVersions := Seq("2.12.12", "2.13.3")
+crossScalaVersions := Seq("2.12.15", "2.13.7", "3.1.0")
 organization := "org.pac4j"
-version      := "2.0.2-SNAPSHOT"
+version      := "3.0.0-SNAPSHOT"
 
-val circeVersion = "0.13.0"
-val http4sVersion = "0.21.6"
-val pac4jVersion = "3.9.0"
+val circeVersion = "0.14.1"
+val http4sVersion = "0.22.7"
+val pac4jVersion = "5.1.5"
 val specs2Version = "4.10.0"
-val catsVersion = "2.1.1"
-val catsEffectVersion = "2.1.3"
-val vaultVersion = "2.0.0"
-val mouseVersion = "0.25"
+val catsVersion = "2.6.1"
+//val catsEffectVersion = "2.1.3"
+val vaultVersion = "2.1.13"
+val mouseVersion = "1.0.7"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
@@ -21,16 +21,23 @@ libraryDependencies ++= Seq(
   "org.slf4j" % "slf4j-api" % "1.7.26",
   "commons-codec" % "commons-codec" % "1.14",
   "org.typelevel" %% "cats-core" % catsVersion,
-  "io.chrisdavenport" %% "vault" % vaultVersion,
+  "org.typelevel" %% "vault" % vaultVersion,
   "org.typelevel" %% "mouse" % mouseVersion,
-
-  "io.circe" %% "circe-optics" % circeVersion % Test,
-  "org.http4s" %% "http4s-jawn" % http4sVersion % Test,
-  "org.specs2" %% "specs2-matcher-extra" % specs2Version % Test,
-  "org.specs2" %% "specs2-scalacheck" % specs2Version % Test,
-  "org.specs2" %% "specs2-cats" % specs2Version,
-
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.6.0",
 )
+
+libraryDependencies ++= {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, _)) => Seq(
+      "io.circe" %% "circe-optics" % circeVersion % Test,
+      "org.http4s" %% "http4s-jawn" % http4sVersion % Test,
+      "org.specs2" %% "specs2-matcher-extra" % specs2Version % Test,
+      "org.specs2" %% "specs2-scalacheck" % specs2Version % Test,
+      "org.specs2" %% "specs2-cats" % specs2Version,
+    )
+    case _ => Seq()
+  }
+}
 
 credentials += Credentials(Path.userHome / ".sbt" / ".credentials")
 
@@ -67,6 +74,7 @@ scalacOptions ++= {
     } else Seq()
 
   partialUnification ++ Seq(
+    "-deprecation",
     "-language:implicitConversions",
     "-language:higherKinds"
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.5.5

--- a/src/main/scala/org/pac4j/http4s/SecurityFilterMiddleware.scala
+++ b/src/main/scala/org/pac4j/http4s/SecurityFilterMiddleware.scala
@@ -1,21 +1,20 @@
 package org.pac4j.http4s
 
 import java.util
-
-import cats.implicits._
 import cats.effect._
-import org.http4s.server.{HttpMiddleware, Middleware}
-import org.http4s.{HttpRoutes, Response}
-
-import cats.effect.IO
+import cats.syntax.flatMap._
+import org.http4s.{AuthedRoutes, ContextRequest, Request, Response}
 import org.http4s.server.AuthMiddleware
-import org.http4s.{AuthedRoutes, ContextRequest, Response}
 import org.http4s.implicits._
 import org.pac4j.core.config.Config
 import org.pac4j.core.engine.{DefaultSecurityLogic, SecurityGrantedAccessAdapter}
-import org.pac4j.core.http.adapter.HttpActionAdapter
-import org.pac4j.core.profile.CommonProfile
+import org.pac4j.core.profile.{CommonProfile, UserProfile}
 import cats.data.{Kleisli, OptionT}
+import org.pac4j.core.context.WebContext
+import org.pac4j.core.context.session.SessionStore
+import org.pac4j.http4s
+
+import scala.collection.JavaConverters._
 
 /**
   * DefaultSecurityGrantedAccessAdapter gets called if user is granted access
@@ -24,15 +23,13 @@ import cats.data.{Kleisli, OptionT}
   *
   * @param service The http4s route that is being protected
   */
-class DefaultSecurityGrantedAccessAdapter(service: AuthedRoutes[util.Collection[CommonProfile], IO])
-    extends SecurityGrantedAccessAdapter[IO[Response[IO]], Http4sWebContext] {
-  override def adapt(
-      context: Http4sWebContext,
-      profiles: util.Collection[CommonProfile],
-      parameters: AnyRef*
-  ): IO[Response[IO]] = {
-    service.orNotFound(ContextRequest(profiles, context.getRequest))
-  }
+class DefaultSecurityGrantedAccessAdapter[F[_] <: AnyRef : Sync](service: AuthedRoutes[List[CommonProfile], F])
+    extends SecurityGrantedAccessAdapter {
+
+  override def adapt(context: WebContext, sessionStore: SessionStore, profiles: util.Collection[UserProfile], parameters: AnyRef*): AnyRef =
+    service.orNotFound(
+      ContextRequest[F, List[CommonProfile]](profiles.asScala.toList.map(_.asInstanceOf[CommonProfile]), context.asInstanceOf[http4s.Http4sWebContext[F]].getRequest)
+    )
 }
 
 /**
@@ -42,35 +39,45 @@ class DefaultSecurityGrantedAccessAdapter(service: AuthedRoutes[util.Collection[
   * @author Iain Cardnell
   */
 object SecurityFilterMiddleware {
-  def securityFilter(
+
+  def defaultSecurityGrantedAccessAdapter[F[_] <: AnyRef : Sync]: AuthedRoutes[List[CommonProfile], F] => SecurityGrantedAccessAdapter =
+    (a: AuthedRoutes[List[CommonProfile], F]) => new DefaultSecurityGrantedAccessAdapter[F](a)
+
+  def securityFilter[F[_] <: AnyRef : Sync](
       config: Config,
       blocker: Blocker,
+      contextBuilder: (Request[F], Config) => Http4sWebContext[F],
       clients: Option[String] = None,
       authorizers: Option[String] = None,
-      matchers: Option[String] = None,
-      multiProfile: Boolean = false,
-      securityGrantedAccessAdapter: AuthedRoutes[util.Collection[CommonProfile], IO] => SecurityGrantedAccessAdapter[
-        IO[Response[IO]],
-        Http4sWebContext
-      ] = new DefaultSecurityGrantedAccessAdapter(_)
-  )(implicit cs: ContextShift[IO]): AuthMiddleware[IO, util.Collection[CommonProfile]] =
+      matchers: Option[String] = None
+  )(implicit cs: ContextShift[F]): AuthMiddleware[F, List[CommonProfile]] =
+    securityFilter(config, blocker, contextBuilder, clients, authorizers, matchers, defaultSecurityGrantedAccessAdapter[F])
+
+  def securityFilter[F[_] : Sync](
+      config: Config,
+      blocker: Blocker,
+      contextBuilder: (Request[F], Config) => Http4sWebContext[F],
+      clients: Option[String],
+      authorizers: Option[String],
+      matchers: Option[String],
+      securityGrantedAccessAdapter: AuthedRoutes[List[CommonProfile], F] => SecurityGrantedAccessAdapter
+  )(implicit cs: ContextShift[F]): AuthMiddleware[F, List[CommonProfile]] =
     service =>
       Kleisli(request => {
         val securityLogic =
-          new DefaultSecurityLogic[IO[Response[IO]], Http4sWebContext]
-        val context = Http4sWebContext(request, config)
+          new DefaultSecurityLogic
+        val context = contextBuilder(request, config)
         OptionT.liftF(
-          blocker.delay[IO, IO[Response[IO]]](securityLogic.perform(
+          blocker.delay[F, F[Response[F]]](securityLogic.perform(
             context,
+            config.getSessionStore,
             config,
             securityGrantedAccessAdapter(service),
-            config.getHttpActionAdapter
-              .asInstanceOf[HttpActionAdapter[IO[Response[IO]], Http4sWebContext]],
+            config.getHttpActionAdapter,
             clients.orNull,
             authorizers.orNull,
-            matchers.orNull,
-            multiProfile
-          )).flatten
+            matchers.orNull
+          ).asInstanceOf[F[Response[F]]]).flatten
         )
       }
     )

--- a/src/test/scala-2/org/pac4j/http4s/Http4sSessionStoreSpec.scala
+++ b/src/test/scala-2/org/pac4j/http4s/Http4sSessionStoreSpec.scala
@@ -2,11 +2,11 @@ package org.pac4j.http4s
 
 import io.circe.{Json, JsonObject}
 import org.specs2.mutable.Specification
-import Http4sCookieSessionStore._
+import cats.effect.IO
 import io.circe.syntax._
 
 object Http4sCookieSessionStoreSpec extends Specification {
-  val store = new Http4sCookieSessionStore {}
+  val store = new Http4sCookieSessionStore[IO] {}
   import store._
 
   "get" should {


### PR DESCRIPTION
Fixes #13 

This is very breaking one, so, I changed SNAPSHOT to 3.0. Breaking not only because of pac4j version bump, but also other changes included.

List of changes:

- changes to make it compatible with pac4j 5.1
- initial Scala 3 cross build support (tests can't be run, because test dependencies are missing Scala 3 support yet)
- deprecation warnings were fixed
- IO implementations were replaced with cats-effect 2 typeclasses alternative, making library usable in more ways.

I have demo application changes https://github.com/pac4j/http4s-pac4j-demo which show that the library is now usable with cats-effect, monix and zio.