### PR TITLE
Cats-effect 3, Vault 3 and http4s 0.23 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,12 +3,11 @@ organization := "org.pac4j"
 version      := "3.0.1-SNAPSHOT"
 
 val circeVersion = "0.14.1"
-val http4sVersion = "0.22.7"
+val http4sVersion = "0.23.6"
 val pac4jVersion = "5.1.5"
-val specs2Version = "4.10.0"
+val specs2Version = "4.12.12"
 val catsVersion = "2.6.1"
-//val catsEffectVersion = "2.1.3"
-val vaultVersion = "2.1.13"
+val vaultVersion = "3.1.0"
 val mouseVersion = "1.0.7"
 
 libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 crossScalaVersions := Seq("2.12.15", "2.13.7", "3.1.0")
 organization := "org.pac4j"
-version      := "3.0.1-SNAPSHOT"
+version      := "4.0.0-SNAPSHOT"
 
 val circeVersion = "0.14.1"
 val http4sVersion = "0.23.6"

--- a/src/main/scala/org/pac4j/http4s/CallbackService.scala
+++ b/src/main/scala/org/pac4j/http4s/CallbackService.scala
@@ -16,17 +16,16 @@ import org.pac4j.core.engine.DefaultCallbackLogic
   * @author Iain Cardnell
   */
 class CallbackService[F[_]: Sync](config: Config,
-    blocker: Blocker,
     contextBuilder: (Request[F], Config) => Http4sWebContext[F],
     defaultUrl: Option[String] = None,
     renewSession: Boolean = true,
     defaultClient: Option[String] = None
-  )(implicit cs: ContextShift[F]){
+  ) {
 
   def callback(request: Request[F]): F[Response[F]] = {
     val callbackLogic = new DefaultCallbackLogic()
     val webContext = contextBuilder(request, config)
-    blocker.delay[F, F[Response[F]]](callbackLogic.perform(webContext,
+    Sync[F].blocking(callbackLogic.perform(webContext,
       config.getSessionStore,
       config,
       config.getHttpActionAdapter,

--- a/src/main/scala/org/pac4j/http4s/Http4sWebContext.scala
+++ b/src/main/scala/org/pac4j/http4s/Http4sWebContext.scala
@@ -1,7 +1,8 @@
 package org.pac4j.http4s
 
 import java.util
-import cats.effect.{IO, Sync, SyncEffect, SyncIO}
+import cats.effect.{IO, Sync, SyncIO}
+import cats.effect.std.Dispatcher
 import cats.syntax.eq._
 import org.http4s._
 import org.pac4j.core.context.session.SessionStore
@@ -207,9 +208,14 @@ class Http4sWebContext[F[_]: Sync](
 
 object Http4sWebContext {
 
-  def ioInstance(request: Request[IO], config: Config) =
+  /** @deprecated
+   *  Use withDispatcherInstance
+   */
+  def ioInstance(request: Request[IO], config: Config) = {
+    import cats.effect.unsafe.implicits.global
     new Http4sWebContext[IO](request, config.getSessionStore, _.unsafeRunSync())
+  }
 
-  def syncEffectInstance[F[_] : SyncEffect](request: Request[F], config: Config) =
-    new Http4sWebContext[F](request, config.getSessionStore, SyncEffect[F].runSync[IO, String](_).unsafeRunSync())
+  def withDispatcherInstance[F[_]: Sync]( dispatcher: Dispatcher[F] )(request: Request[F], config: Config) =
+    new Http4sWebContext[F](request, config.getSessionStore, dispatcher.unsafeRunSync)
 }

--- a/src/main/scala/org/pac4j/http4s/LogoutService.scala
+++ b/src/main/scala/org/pac4j/http4s/LogoutService.scala
@@ -12,19 +12,18 @@ import org.pac4j.core.engine.DefaultLogoutLogic
   * @author Iain Cardnell
   */
 class LogoutService[F[_]: Sync](config: Config,
-    blocker: Blocker,
     contextBuilder: (Request[F], Config) => Http4sWebContext[F],
     defaultUrl: Option[String] = None,
     logoutUrlPattern: Option[String] = None,
     localLogout: Boolean = true,
     destroySession: Boolean = false,
     centralLogout: Boolean = false
-  )(implicit cs: ContextShift[F]) {
+  ) {
 
   def logout(request: Request[F]): F[Response[F]] = {
     val logoutLogic = new DefaultLogoutLogic()
     val webContext = contextBuilder(request, config)
-    blocker.delay[F, F[Response[F]]](logoutLogic.perform(webContext,
+    Sync[F].blocking(logoutLogic.perform(webContext,
       config.getSessionStore,
       config,
       config.getHttpActionAdapter,

--- a/src/test/scala-2/org/pac4j/http4s/SessionSpec.scala
+++ b/src/test/scala-2/org/pac4j/http4s/SessionSpec.scala
@@ -2,6 +2,7 @@ package org.pac4j.http4s
 
 import cats.syntax.all._
 import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import Generators._
 import Matchers._
 import SessionSyntax._
@@ -77,8 +78,6 @@ class SessionSpec(val exEnv: ExecutionEnv) extends Specification with ScalaCheck
     def toRequestCookie: RequestCookie = RequestCookie(c.name, c.content)
   }
   import implicits._
-  implicit val cs = IO.contextShift(exEnv.executionContext)
-  implicit val ti = IO.timer(exEnv.executionContext)
 
   val config = SessionConfig(
     cookieName = "session",


### PR DESCRIPTION
This is a proposal to upgrade the dependency on http4s to 0.23.x

I understand that this proposal is not a light change and may well require some discussion.

This PR contains breaking changes, so I preemptively bumped the version to 4.0-SNAPSHOT.

The main breaking changes are the removal of `SafeEffect[F]` in favor of `Dispatcher[F]` (I think the best way for the library is to allow the user to provide the Dispatcher), and `Blocker.delay` in favor of `Sync[F].blocking`

I guess it would be your preference to keep maintaining both http4s 0.22 - cats effect 2 and http4s 0.23 - cats effect 3 builds.

The PR is ready to merge onto master, but feel free to change targeted branch as needed

Fix #17 