### PR TITLE
Stream Exhausted Exception Fix

### DIFF
--- a/src/main/scala/org/pac4j/http4s/Http4sWebContext.scala
+++ b/src/main/scala/org/pac4j/http4s/Http4sWebContext.scala
@@ -168,7 +168,7 @@ class Http4sWebContext[F[_]: Sync](
 
   override def getPath: String = request.uri.path.toString
 
-  override def getRequestContent: String =
+  override lazy val getRequestContent: String =
     bodyExtractor(request.bodyText.compile.to(Collector.string))
 
   override def getProtocol: String = request.uri.scheme.get.value


### PR DESCRIPTION
In latest blaze/ember versions we have an issue.
Since `Stream[F[_], A]` is "single-used entity", 
and we try to access `getRequestContent` more than once during `getRequestParameter`
we have an exception.
So, we decided to make it `lazy val` to evaluate only once and cache it.
P.S. I found it when I use SSO-SAML when I needed to extract `RelayState` and `SAMLRequest`
from the POST body