### PR TITLE
Avoid passing AES key as utf8 string

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 crossScalaVersions := Seq("2.12.15", "2.13.7", "3.1.0")
 organization := "org.pac4j"
-version      := "4.0.2-SNAPSHOT"
+version      := "4.1.0-SNAPSHOT"
 
 val circeVersion = "0.14.1"
 val http4sVersion = "0.23.6"

--- a/src/test/scala-2/org/pac4j/http4s/SessionSpec.scala
+++ b/src/test/scala-2/org/pac4j/http4s/SessionSpec.scala
@@ -82,7 +82,7 @@ class SessionSpec(val exEnv: ExecutionEnv) extends Specification with ScalaCheck
   val config = SessionConfig(
     cookieName = "session",
     mkCookie = ResponseCookie(_, _),
-    secret = "this is a secret",
+    secret = List.fill(16)(0xff.toByte),
     maxAge = 5.minutes
   )
 
@@ -158,7 +158,7 @@ class SessionSpec(val exEnv: ExecutionEnv) extends Specification with ScalaCheck
 
       "read None when the session is signed with a different secret" in prop { session: Session =>
          config
-           .copy(secret = "this is a different secret")
+           .copy(secret = List.fill(16)(0xaa.toByte))
            .cookie[IO](session.noSpaces)
            .map(cookie =>
              Request[IO](Method.GET, uri"/read").addCookie(cookie.toRequestCookie)


### PR DESCRIPTION
I've recently been using `http4s-pac4j` and have been surprised that the secret/key used to authenticate/cipher the session cookie is passed as an (utf8) string which, in my opinion, is a poor format for a key.

There is a false equivalence between a byte and a utf8 character
- utf8 can have multiple bytes per character
- among the first 255 "valid" utf8 chars, there are many unrepresentable or rarely used characters (like control characters). This will effectively reduce the key's entropy (instead of 256^16 the key might only have 64^16 possible values).

I think it's best to accept bytes directly to avoid errors (or have some overloaded constructors at least).

In addition, the cookie is decrypted before being authenticated. It's better to do it the other way around, I swapped the operations.

Finally, the same key is used to sign and encrypt the cookie, there is no KDF in the Java standard library, so I left it as is. I think that in this case it's fine (since HMac and AES are used), but it's usually a read flag in cryptography.