### PR TITLE
Replace Pac4jUserProfiles case class with type alias to fix cast exception

### DIFF
--- a/src/main/scala/org/pac4j/http4s/Http4sWebContext.scala
+++ b/src/main/scala/org/pac4j/http4s/Http4sWebContext.scala
@@ -39,7 +39,7 @@ class Http4sWebContext[F[_]: Sync](
 
   private var response: Response[F] = Response()
 
-  case class Pac4jUserProfiles(pac4jUserProfiles: util.LinkedHashMap[String, CommonProfile])
+  type Pac4jUserProfiles = util.LinkedHashMap[String, CommonProfile]
 
   val pac4jUserProfilesAttr: Key[Pac4jUserProfiles] =
     Key.newKey[SyncIO, Pac4jUserProfiles].unsafeRunSync()
@@ -98,7 +98,7 @@ class Http4sWebContext[F[_]: Sync](
     logger.debug(s"setRequestAttribute: $name")
     request = name match {
       case Pac4jConstants.USER_PROFILES =>
-        request.withAttribute(pac4jUserProfilesAttr, Pac4jUserProfiles(value.asInstanceOf[util.LinkedHashMap[String, CommonProfile]]))
+        request.withAttribute(pac4jUserProfilesAttr, value.asInstanceOf[Pac4jUserProfiles])
       case Pac4jConstants.SESSION_ID =>
         request.withAttribute(sessionIdAttr, value.asInstanceOf[String])
       case Pac4jConstants.CSRF_TOKEN =>


### PR DESCRIPTION
Hi,

This PR replaces the case class Pac4jUserProfiles with a type alias as explained in https://github.com/pac4j/http4s-pac4j/issues/25

It fixes the issue I encountered using the minimal sample provided in the associated issue.

My understanding of this issue is that in the file: https://github.com/pac4j/pac4j/blob/pac4j-parent-5.7.1/pac4j-core/src/main/java/org/pac4j/core/profile/ProfileManager.java in the `retrieveAll` function, the retrieved value that is expected is a `Map[String, UserProfile]` but `Http4sWebContext` responds with a `Pac4jUserProfiles` case class, thus leading to a class cast exception.

The original `Pac4jUserProfiles` type (case class) has no other reference outside of `Http4sWebContext` so its removal should not break something on the project itself. Nonetheless, this case class was not private so it may be used in users code.

I don't know pac4j enough yet to know when this `retrieveAll` is called and how this issue may affect or not the other users, but if my understanding is good every function relying on  `retrieveAll` and more generally calling the `context.getRequestAttribute(Pac4jConstants.USER_PROFILES)` while expecting a `Map[String, UserProfile]` should be broken.

Regards,