### PR TITLE
Create GenericSessionStore and SessionRepository

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 crossScalaVersions := Seq("2.12.18", "2.13.12", "3.3.1")
 organization := "org.pac4j"
-version      := "4.3.1-SNAPSHOT"
+version      := "4.4.0-SNAPSHOT"
 
 val circeVersion = "0.14.6"
 val http4sVersion = "0.23.25"
@@ -9,6 +9,7 @@ val specs2Version = "4.20.3"
 val catsVersion = "2.10.0"
 val vaultVersion = "3.5.0"
 val mouseVersion = "1.2.2"
+val catsEffectTestingVersion = "1.5.0"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
@@ -30,6 +31,7 @@ libraryDependencies ++= Seq(
   "org.specs2" %% "specs2-matcher-extra" % specs2Version % Test,
   "org.specs2" %% "specs2-scalacheck" % specs2Version % Test,
   "org.specs2" %% "specs2-cats" % specs2Version % Test,
+  "org.typelevel" %% "cats-effect-testing-specs2" % catsEffectTestingVersion % Test
 )
 
 libraryDependencies ++= {

--- a/src/main/scala/org/pac4j/http4s/CacheSessionRepository.scala
+++ b/src/main/scala/org/pac4j/http4s/CacheSessionRepository.scala
@@ -1,0 +1,40 @@
+package org.pac4j.http4s
+
+import cats.syntax.all._
+import cats.Applicative
+import scala.annotation.tailrec
+
+class CacheSessionRepository[F[_]: Applicative] extends SessionRepository[F] {
+  import scala.collection.concurrent.{Map => ConcurrentMap}
+  private val cache =
+    scala.collection.concurrent.TrieMap[String, Map[String, AnyRef]]()
+
+  override def remove(id: String, key: String): F[Unit] =
+    insertOrUpdate(cache)(id)(Map.empty, _ - key).pure[F]
+
+  override def set(id: String, key: String, value: AnyRef): F[Unit] =
+    insertOrUpdate(cache)(id)(Map(key -> value), _ + (key -> value)).pure[F]
+
+  override def deleteSession(id: String): F[Boolean] =
+    cache.remove(id).isDefined.pure[F]
+
+  override def get(id: String): F[Option[Map[String, AnyRef]]] =
+    cache.get(id).pure[F]
+
+  override def update(id: String, session: Map[String, AnyRef]): F[Unit] =
+    cache.update(id, session).pure[F]
+
+  private def insertOrUpdate[K, V](
+      map: ConcurrentMap[K, V]
+  )(key: K)(insert: V, update: V => V): Unit = {
+    @tailrec
+    def go(): Unit = {
+      map.putIfAbsent(key, insert) match {
+        case Some(prev) if map.replace(key, prev, update(prev)) => ()
+        case Some(_)                                            => go()
+        case None                                               => ()
+      }
+    }
+    go()
+  }
+}

--- a/src/main/scala/org/pac4j/http4s/Http4sCacheSessionStore.scala
+++ b/src/main/scala/org/pac4j/http4s/Http4sCacheSessionStore.scala
@@ -30,6 +30,7 @@ import org.http4s.SameSite
   *
   * @author Iain Cardnell
   */
+@deprecated("Use Http4sGenericSessionStore in combination with CacheSessionRepository instead", since = "4.4.0")
 class Http4sCacheSessionStore[F[_] : Sync](
   maxAge: Option[Int] = None,
   domain: Option[String] = None,

--- a/src/main/scala/org/pac4j/http4s/Http4sGenericSessionStore.scala
+++ b/src/main/scala/org/pac4j/http4s/Http4sGenericSessionStore.scala
@@ -1,0 +1,156 @@
+package org.pac4j.http4s
+
+import cats.effect.Sync
+import cats.effect.std.Dispatcher
+import org.http4s.SameSite
+import org.pac4j.core.context.{Cookie, WebContext}
+import org.pac4j.core.context.session.SessionStore
+import org.pac4j.core.util.Pac4jConstants
+import org.slf4j.LoggerFactory
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
+import cats.effect.std.UUIDGen
+import java.util.Optional
+
+/** Http4sGenericSessionStore is a generic session implementation with
+  * configurable storage
+  *
+  * The cookie will just contain an id and the session data is kept server side
+  * in `storage`.
+  *
+  * @param maxAge
+  *   `Max-Age` cookie attribute
+  * @param domain
+  *   `Domain` cookie attribute
+  * @param path
+  *   `Path` cookie attribute
+  * @param secure
+  *   `Secure` cookie attribute
+  * @param httpOnly
+  *   `HttpOnly` cookie attribute
+  *
+  * @author
+  *   Iain Cardnell
+  */
+class Http4sGenericSessionStore[F[_]: Sync](
+    sessionRepository: SessionRepository[F],
+    dispatcher: Dispatcher[F]
+)(
+    maxAge: Option[Int] = None,
+    domain: Option[String] = None,
+    path: Option[String] = Some("/"),
+    secure: Boolean = false,
+    httpOnly: Boolean = false,
+    sameSite: Option[SameSite] = None
+) extends SessionStore {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+
+  override def getSessionId(
+      context: WebContext,
+      createSession: Boolean
+  ): Optional[String] = {
+    val id =
+      context.getRequestAttribute(Pac4jConstants.SESSION_ID).toScala match {
+        case Some(sessionId) => Some(sessionId.toString)
+        case None =>
+          context.getRequestCookies.asScala.find(
+            _.getName == Pac4jConstants.SESSION_ID
+          ) match {
+            case Some(cookie) => Option(cookie.getValue)
+            case None if createSession =>
+              Some(createSessionId(context.asInstanceOf[Http4sWebContext[F]]))
+            case None => None
+          }
+      }
+    logger.debug(s"getOrCreateSessionId - $id")
+    id.toJava
+  }
+
+  private def createSessionId(context: Http4sWebContext[F]): String = {
+    val id = dispatcher.unsafeRunSync(UUIDGen[F].randomUUID).toString()
+    context.setRequestAttribute(Pac4jConstants.SESSION_ID, id)
+
+    val cookie = new Cookie(Pac4jConstants.SESSION_ID, id)
+    maxAge.foreach(cookie.setMaxAge)
+    domain.foreach(cookie.setDomain)
+    path.foreach(cookie.setPath)
+    cookie.setSecure(secure)
+    cookie.setHttpOnly(httpOnly)
+    sameSite.foreach(s => cookie.setSameSitePolicy(s.renderString))
+
+    context.addResponseCookie(cookie)
+    id
+  }
+
+  override def get(context: WebContext, key: String): Optional[AnyRef] = {
+    val sessionId = getSessionId(context, createSession = false)
+    sessionId.flatMap[AnyRef] { sid =>
+      val value = dispatcher
+        .unsafeRunSync(sessionRepository.get(sid))
+        .getOrElse(Map.empty)
+        .get(key)
+        .toJava
+      logger.debug(s"get sessionId: $sessionId key: $key")
+      value
+    }
+  }
+
+  override def set(context: WebContext, key: String, value: AnyRef): Unit = {
+    val sessionId = getSessionId(context, createSession = true).get()
+    if (value == null) {
+      dispatcher.unsafeRunSync(sessionRepository.remove(sessionId, key))
+    } else
+      dispatcher.unsafeRunSync(sessionRepository.set(sessionId, key, value))
+  }
+
+  override def destroySession(context: WebContext): Boolean = {
+    val sessionId = getSessionId(context, createSession = false).toScala
+    val deleted = sessionId.exists(id =>
+      dispatcher.unsafeRunSync(sessionRepository.deleteSession(id))
+    )
+    if (deleted) {
+      context.setRequestAttribute(Pac4jConstants.SESSION_ID, null)
+      context
+        .asInstanceOf[Http4sWebContext[F]]
+        .removeResponseCookie(Pac4jConstants.SESSION_ID)
+    }
+    deleted
+  }
+
+  override def getTrackableSession(context: WebContext): Optional[AnyRef] = {
+    logger.debug(s"getTrackableSession")
+    getSessionId(context, false).asInstanceOf[Optional[AnyRef]]
+  }
+
+  override def buildFromTrackableSession(
+      context: WebContext,
+      trackableSession: Any
+  ): Optional[SessionStore] = {
+    context.setRequestAttribute(
+      Pac4jConstants.SESSION_ID,
+      trackableSession.toString
+    )
+    Optional.of(this)
+  }
+
+  override def renewSession(context: WebContext): Boolean = {
+    val oldSessionId = getSessionId(context, false)
+    val oldData = oldSessionId.flatMap(sid =>
+      dispatcher.unsafeRunSync(sessionRepository.get(sid)).toJava
+    )
+
+    destroySession(context)
+
+    val newSessionId = createSessionId(
+      context.asInstanceOf[Http4sWebContext[F]]
+    )
+    if (oldData.isPresent) {
+      dispatcher.unsafeRunSync(
+        sessionRepository.update(newSessionId, oldData.get)
+      )
+    }
+    logger.debug(s"Renewed session: $oldSessionId -> $newSessionId")
+    true
+  }
+}

--- a/src/main/scala/org/pac4j/http4s/SessionRepository.scala
+++ b/src/main/scala/org/pac4j/http4s/SessionRepository.scala
@@ -1,0 +1,11 @@
+package org.pac4j.http4s
+
+/** Repository trait for customizing Http4sGenericSessionStore.
+  */
+trait SessionRepository[F[_]] {
+  def get(id: String): F[Option[Map[String, AnyRef]]]
+  def set(id: String, key: String, value: AnyRef): F[Unit]
+  def remove(id: String, key: String): F[Unit]
+  def update(id: String, session: Map[String, AnyRef]): F[Unit]
+  def deleteSession(id: String): F[Boolean]
+}

--- a/src/test/scala/org/pac4j/http4s/Http4sGenericSessionStoreSpec.scala
+++ b/src/test/scala/org/pac4j/http4s/Http4sGenericSessionStoreSpec.scala
@@ -1,0 +1,197 @@
+package org.pac4j.http4s
+
+import org.specs2.mutable.Specification
+import cats.effect.testing.specs2.CatsEffect
+import cats.effect.IO
+import cats.effect.std.Dispatcher
+import org.http4s.Request
+import org.pac4j.core.util.Pac4jConstants
+
+import scala.jdk.CollectionConverters._
+import scala.jdk.OptionConverters._
+
+object Http4sGenericSessionStoreSpec extends Specification with CatsEffect {
+  "getSessionId retrieves SessionId from requestAttribute" >> {
+    Dispatcher.parallel[IO].use { dispatcher =>
+      val expectedSessionId = "sessionId"
+      val sessionRepository = new CacheSessionRepository[IO]
+      val underTest =
+        new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+      val request = Request[IO]()
+      val webContext =
+        new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+      webContext
+        .setRequestAttribute(Pac4jConstants.SESSION_ID, expectedSessionId)
+      val sessionId = underTest.getSessionId(webContext, false).toScala
+      IO(sessionId must beSome(expectedSessionId))
+    }
+  }
+
+  "getSessionId retrieves SessionId from cookie" >> {
+    Dispatcher.parallel[IO].use { dispatcher =>
+      val expectedSessionId = "sessionId"
+      val sessionRepository = new CacheSessionRepository[IO]
+      val underTest =
+        new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+      val request =
+        Request[IO]().addCookie(Pac4jConstants.SESSION_ID, expectedSessionId)
+      val webContext =
+        new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+      val sessionId = underTest.getSessionId(webContext, false).toScala
+      IO(sessionId must beSome(expectedSessionId))
+    }
+  }
+
+  "getSessionId does not create new session if not asked for it" >> {
+    Dispatcher.parallel[IO].use { dispatcher =>
+      val sessionRepository = new CacheSessionRepository[IO]
+      val request = Request[IO]()
+      val underTest =
+        new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+      val webContext =
+        new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+      val sessionId = underTest.getSessionId(webContext, false).toScala
+      IO(sessionId must beNone)
+    }
+  }
+
+  "getSessionId creates new session and sets according cookie" >> {
+    Dispatcher.parallel[IO].use { dispatcher =>
+      val sessionRepository = new CacheSessionRepository[IO]
+      val underTest =
+        new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+      val request = Request[IO]()
+      val webContext =
+        new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+      val sessionId = underTest.getSessionId(webContext, true).toScala
+      val sessionIdKey = Pac4jConstants.SESSION_ID
+      IO(
+        (sessionId must beSome)
+          and (webContext
+            .getRequestAttribute(sessionIdKey)
+            .toScala must_== (sessionId))
+          and (webContext.getResponse.cookies
+            .find(_.name == sessionIdKey)
+            .map(_.content) must_== sessionId)
+      )
+    }
+
+    "get from underlying SessionRepository" >> {
+      Dispatcher.parallel[IO].use { dispatcher =>
+        val sessionId = "sessionId"
+        val sessionRepository = new CacheSessionRepository[IO]
+        val underTest =
+          new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+        val request =
+          Request[IO]().addCookie(Pac4jConstants.SESSION_ID, sessionId)
+        val webContext =
+          new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+        for {
+          _ <- sessionRepository.set(sessionId, "key", "value")
+          value = underTest.get(webContext, "key").toScala
+        } yield value must beSome("value")
+      }
+    }
+
+    "return None on get for unknown SessionId" >> {
+      Dispatcher.parallel[IO].use { dispatcher =>
+        val sessionRepository = new CacheSessionRepository[IO]
+        val underTest =
+          new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+        val request = Request[IO]()
+        val webContext =
+          new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+        val value = underTest.get(webContext, "key").toScala
+        IO(value must beNone)
+      }
+    }
+
+    "set to underlying SessionRepository" >> {
+      Dispatcher.parallel[IO].use { dispatcher =>
+        val sessionId = "sessionId"
+        val sessionRepository = new CacheSessionRepository[IO]
+        val underTest =
+          new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+        val request =
+          Request[IO]().addCookie(Pac4jConstants.SESSION_ID, sessionId)
+        val webContext =
+          new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+        underTest.set(webContext, "key", "value")
+        for {
+          session <- sessionRepository.get(sessionId)
+          value = session.getOrElse(Map.empty).get("key")
+        } yield value must beSome("value")
+      }
+    }
+
+    "set `null` removes underlying from SessionRepository" >> {
+      Dispatcher.parallel[IO].use { dispatcher =>
+        val sessionId = "sessionId"
+        val sessionRepository = new CacheSessionRepository[IO]
+        val underTest =
+          new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+        val request =
+          Request[IO]().addCookie(Pac4jConstants.SESSION_ID, sessionId)
+        val webContext =
+          new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+        for {
+          _ <- sessionRepository.set(sessionId, "key", "should vanish")
+          _ = underTest.set(webContext, "key", null)
+          session <- sessionRepository.get(sessionId)
+          value = session.getOrElse(Map.empty).get("key")
+        } yield value must beNone
+      }
+    }
+
+    "destroySession removes session from SessionRepository and Context" >> {
+      Dispatcher.parallel[IO].use { dispatcher =>
+        val sessionId = "sessionId"
+        val sessionRepository = new CacheSessionRepository[IO]
+        val underTest =
+          new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+        val request = Request[IO]()
+        val webContext =
+          new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+        webContext.setRequestAttribute(Pac4jConstants.SESSION_ID, sessionId)
+        for {
+          _ <- sessionRepository.set(sessionId, "key", "should vanish")
+          _ = underTest.destroySession(webContext)
+          session <- sessionRepository.get(sessionId)
+          sessionIdAttribute = webContext
+            .getRequestAttribute(Pac4jConstants.SESSION_ID)
+            .toScala
+          sessionIdCookie = webContext.getRequestCookies.asScala
+            .find(_.getName() == Pac4jConstants.SESSION_ID)
+        } yield (session must beNone) and (sessionIdAttribute must beNone) and (sessionIdCookie must beNone)
+      }
+    }
+
+    "renewSession moves data from old session to new one" >> {
+      Dispatcher.parallel[IO].use { dispatcher =>
+        val oldSessionId = "oldSessionId"
+        val sessionRepository = new CacheSessionRepository[IO]
+        val underTest =
+          new Http4sGenericSessionStore[IO](sessionRepository, dispatcher)()
+        val request = Request[IO]()
+        val webContext =
+          new Http4sWebContext[IO](request, dispatcher.unsafeRunSync)
+        webContext.setRequestAttribute(Pac4jConstants.SESSION_ID, oldSessionId)
+        for {
+          _ <- sessionRepository.set(oldSessionId, "key", "value")
+          _ = underTest.renewSession(webContext)
+          oldSession <- sessionRepository.get(oldSessionId)
+          newSessionId = webContext
+            .getRequestAttribute(Pac4jConstants.SESSION_ID)
+            .toScala
+            .get
+            .asInstanceOf[String]
+          newSession <- sessionRepository.get(newSessionId)
+          newValue = newSession.flatMap(s => s.get("key"))
+        } yield (oldSession must beNone) and (newSessionId must be_!=(
+          oldSessionId
+        )) and (newValue must beSome("value"))
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
I needed something similar to `Http4sCacheSessionStore` storing the data at another place as the in-memory cache.
I therefore extracted the store itself to a separate trait(`SessionRepository`) and created `Http4sGenericSessionStore`. This allows library users to implement the trait with a storage of their choice. I copied the current cache implementation to `CacheSessionRepository`. 

 If one combines the  `Http4sGenericSessionStore` with `CacheSessionRepository` it resembles the same logic as `Http4sCacheSessionStore`. Therefore I opted to deprecated `Http4sCacheSessionStore`. If this is not what you like, I can revert the deprecation.

Another positive impact of this change is that it is easier to write unit tests for `Http4sGenericSessionStore`. 