### PR TITLE
Update pac4j-core to 6.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Java CI
 
 env:
-  JDK_CURRENT: 11.0.10
+  JDK_CURRENT: 17.0.10
   DISTRIBUTION: zulu
 
 on:

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 crossScalaVersions := Seq("2.12.18", "2.13.12", "3.3.1")
 organization := "org.pac4j"
-version      := "4.4.1-SNAPSHOT"
+version      := "5.0.0-SNAPSHOT"
 
 val circeVersion = "0.14.6"
 val http4sVersion = "0.23.25"
-val pac4jVersion = "5.7.2"
+val pac4jVersion = "6.0.2"
 val specs2Version = "4.20.3"
 val catsVersion = "2.10.0"
 val vaultVersion = "3.5.0"

--- a/src/main/scala/org/pac4j/http4s/Http4sWebContext.scala
+++ b/src/main/scala/org/pac4j/http4s/Http4sWebContext.scala
@@ -228,6 +228,6 @@ object Http4sWebContext {
     new Http4sWebContext[IO](request, _.unsafeRunSync())
   }
 
-  def withDispatcherInstance[F[_]: Sync]( dispatcher: Dispatcher[F] )(request: Request[F], config: Config) =
+  def withDispatcherInstance[F[_]: Sync](dispatcher: Dispatcher[F])(request: Request[F]) =
     new Http4sWebContext[F](request, dispatcher.unsafeRunSync)
 }

--- a/src/main/scala/org/pac4j/http4s/package.scala
+++ b/src/main/scala/org/pac4j/http4s/package.scala
@@ -1,10 +1,13 @@
 package org.pac4j
 
 import io.circe.Json
+import org.http4s.Request
 
 package object http4s {
   /*
    * Session objects are just Json
    */
   type Session = Json
+
+  type Http4sContextBuilder[F[_]] = Request[F] => Http4sWebContext[F]
 }


### PR DESCRIPTION
This updates the to the latest major of `pac4j-core`.

I've bumped the major version of `http4s-pac4j` since these are breaking changes.

I have not made use of the new `FrameworkParameter` interface, as it seems unnecessary with `http4s`, but I would appreciate some feedback/review on the matter as I might have misunderstood the concept.